### PR TITLE
fix: clarify beta signup is for the iOS app (#12)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -79,9 +79,13 @@ export default function HomePage() {
         {/* Beta signup */}
         <section className="flex flex-col items-center px-4 pb-16">
           <div className="w-full max-w-[480px] rounded-(--radius-card) border border-border-subtle bg-bg-medium p-8 text-center shadow-[0_4px_24px_rgba(0,0,0,0.06)] max-sm:p-5">
-            <h2 className="mb-2 text-2xl font-bold">Join the beta</h2>
+            <span className="mb-3 inline-block rounded-full bg-accent/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-accent">
+              Coming to iOS
+            </span>
+            <h2 className="mb-2 text-2xl font-bold">Get early access to the app</h2>
             <p className="mb-6 text-lg text-text-muted">
-              in prose is in early beta. Sign up to get access.
+              The in prose iOS app is in early beta. Sign up to be first in
+              line.
             </p>
             <SignupForm />
           </div>

--- a/src/app/signup-form.tsx
+++ b/src/app/signup-form.tsx
@@ -102,7 +102,7 @@ export function SignupForm() {
   if (state === "success") {
     return (
       <p className="py-2 text-lg leading-relaxed">
-        You&apos;re on the list! We&apos;ll be in touch when beta access opens.
+        You&apos;re on the list! We&apos;ll be in touch when the app is ready for you.
       </p>
     );
   }
@@ -138,7 +138,7 @@ export function SignupForm() {
         disabled={state === "submitting"}
         className="w-full cursor-pointer rounded-(--radius-input) bg-accent px-6 py-3 font-serif text-lg font-bold text-white transition-opacity hover:opacity-88 disabled:cursor-default disabled:opacity-55"
       >
-        {state === "submitting" ? "Sending..." : "Request beta access"}
+        {state === "submitting" ? "Sending..." : "Request app access"}
       </button>
     </form>
   );


### PR DESCRIPTION
## Summary
- Add "Coming to iOS" pill badge above the beta signup card
- Update heading, description, button text, and success message to clearly reference the iOS app
- No changes to form fields or backend

## Fixes
Closes #12

Generated with [Claude Code](https://claude.com/claude-code)