### PR TITLE
fix: auth redirects with return-to and contextual messaging (#20)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -23,6 +23,8 @@ function LoginForm() {
   const searchParams = useSearchParams();
 
   const callbackError = searchParams.get("error");
+  const nextPath = searchParams.get("next");
+  const contextMessage = searchParams.get("message");
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -51,7 +53,12 @@ function LoginForm() {
       return;
     }
 
-    router.push("/");
+    // Redirect to the original page, or home. Only allow relative paths.
+    const destination =
+      nextPath && nextPath.startsWith("/") && !nextPath.startsWith("//")
+        ? nextPath
+        : "/";
+    router.push(destination);
     router.refresh();
   }
 
@@ -68,6 +75,12 @@ function LoginForm() {
 
       <div className="w-full max-w-sm rounded-(--radius-card) border border-border-subtle bg-bg-medium p-8 shadow-[0_4px_24px_rgba(0,0,0,0.06)]">
         <h1 className="mb-6 text-center text-3xl font-bold">Log in</h1>
+
+        {contextMessage && (
+          <p className="mb-4 rounded-(--radius-input) bg-accent/10 p-3 text-center text-sm text-text-muted">
+            {contextMessage}
+          </p>
+        )}
 
         {callbackError && (
           <p className="mb-4 rounded-(--radius-input) bg-error/10 p-3 text-sm text-error">

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -48,7 +48,27 @@ export async function updateSession(request: NextRequest) {
 
   if (isProtected && !user) {
     const url = request.nextUrl.clone();
+    const originalPath = request.nextUrl.pathname;
     url.pathname = "/login";
+    url.searchParams.set("next", originalPath);
+
+    // Add contextual message based on the route
+    const messages: Record<string, string> = {
+      "/library": "Log in to access your library",
+      "/search": "Log in to search and add books",
+      "/friends": "Log in to see your friends",
+      "/feed": "Log in to view your feed",
+      "/settings": "Log in to access settings",
+      "/contact": "Log in to contact us",
+      "/account": "Log in to access your account",
+    };
+    const message = Object.entries(messages).find(([route]) =>
+      originalPath.startsWith(route)
+    )?.[1];
+    if (message) {
+      url.searchParams.set("message", message);
+    }
+
     return NextResponse.redirect(url);
   }
 


### PR DESCRIPTION
## Summary
- Middleware now passes ?next= and ?message= query params when redirecting unauthenticated users to /login
- Login page reads ?next= and redirects back to the original page after successful login
- Contextual message shown on login page (e.g. "Log in to access your library")
- Open redirect protection: only relative paths accepted for ?next=

### Note
The issue also mentions making search accessible to anonymous users and auditing public profiles. These are larger scope changes that should be separate tickets — this PR focuses on the redirect/messaging infrastructure.

## Fixes
Closes #20

Generated with [Claude Code](https://claude.com/claude-code)