### PR TITLE
feat: social features — friends, activity feed, profiles (#8)

### DIFF
--- a/src/app/(protected)/feed/page.tsx
+++ b/src/app/(protected)/feed/page.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { useAuth } from "@/components/auth-provider";
+import Link from "next/link";
+
+type ActivityItem = {
+  id: string;
+  user_id: string;
+  display_name: string;
+  username: string;
+  avatar_url: string | null;
+  isbn13: string;
+  title: string;
+  cover_url: string | null;
+  activity_type: string;
+  rating: number | null;
+  review: string | null;
+  activity_at: string;
+};
+
+type ActivityFilter = "all" | "started" | "finished" | "reviewed";
+
+const FILTER_LABELS: Record<ActivityFilter, string> = {
+  all: "All",
+  started: "Started",
+  finished: "Finished",
+  reviewed: "Reviewed",
+};
+
+const PAGE_SIZE = 20;
+
+export default function FeedPage() {
+  const { user } = useAuth();
+  const [items, setItems] = useState<ActivityItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [filter, setFilter] = useState<ActivityFilter>("all");
+  const [hasMore, setHasMore] = useState(true);
+
+  const loadFeed = useCallback(
+    async (offset = 0, append = false) => {
+      if (!user) return;
+      const supabase = createClient();
+
+      const activityType = filter === "all" ? null : filter;
+      const { data } = await supabase.rpc("get_friends_activity_feed", {
+        activity_type: activityType,
+        lim: PAGE_SIZE,
+        off: offset,
+      });
+
+      const results = (data as ActivityItem[]) ?? [];
+
+      if (append) {
+        setItems((prev) => [...prev, ...results]);
+      } else {
+        setItems(results);
+      }
+
+      setHasMore(results.length === PAGE_SIZE);
+      setLoading(false);
+      setLoadingMore(false);
+    },
+    [user, filter]
+  );
+
+  useEffect(() => {
+    setLoading(true);
+    setItems([]);
+    loadFeed(0, false);
+  }, [loadFeed]);
+
+  function handleLoadMore() {
+    setLoadingMore(true);
+    loadFeed(items.length, true);
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-6 pt-4 pb-12 max-sm:px-4">
+      <h1 className="mb-6 text-3xl font-bold">Activity feed</h1>
+
+      {/* Filters */}
+      <div className="mb-6 flex flex-wrap gap-2">
+        {(Object.keys(FILTER_LABELS) as ActivityFilter[]).map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={`cursor-pointer rounded-full px-4 py-1.5 text-sm font-semibold transition-colors ${
+              filter === f
+                ? "bg-accent text-white"
+                : "bg-bg-medium text-text-muted hover:bg-accent/10"
+            }`}
+          >
+            {FILTER_LABELS[f]}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <p className="py-12 text-center text-text-muted">Loading feed...</p>
+      ) : items.length === 0 ? (
+        <p className="py-12 text-center text-text-muted">
+          No activity yet. Add some friends to see what they&apos;re reading!
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <ActivityCard key={item.id} item={item} />
+          ))}
+
+          {hasMore && (
+            <button
+              onClick={handleLoadMore}
+              disabled={loadingMore}
+              className="mt-4 w-full cursor-pointer rounded-(--radius-input) border border-border py-3 text-sm font-semibold text-text-muted transition-colors hover:bg-bg-medium disabled:opacity-55"
+            >
+              {loadingMore ? "Loading..." : "Load more"}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ActivityCard({ item }: { item: ActivityItem }) {
+  const actionText = {
+    started: "started reading",
+    finished: "finished",
+    reviewed: "reviewed",
+  }[item.activity_type] ?? item.activity_type;
+
+  const timeAgo = formatTimeAgo(item.activity_at);
+
+  return (
+    <div className="rounded-(--radius-card) border border-border-subtle bg-bg-medium p-4">
+      {/* User info */}
+      <div className="mb-3 flex items-center gap-2">
+        <Link href={`/friends/${item.user_id}`}>
+          {item.avatar_url ? (
+            /* eslint-disable-next-line @next/next/no-img-element */
+            <img
+              src={item.avatar_url}
+              alt={item.display_name}
+              className="h-8 w-8 rounded-full object-cover"
+            />
+          ) : (
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-accent/15 text-xs font-bold text-accent">
+              {item.display_name?.[0]?.toUpperCase() ?? "?"}
+            </div>
+          )}
+        </Link>
+        <div className="flex-1">
+          <p className="text-sm">
+            <Link
+              href={`/friends/${item.user_id}`}
+              className="font-semibold hover:underline"
+            >
+              {item.display_name}
+            </Link>{" "}
+            <span className="text-text-muted">{actionText}</span>
+          </p>
+          <p className="text-xs text-text-subtle">{timeAgo}</p>
+        </div>
+      </div>
+
+      {/* Book info */}
+      <div className="flex gap-3">
+        <div className="h-[72px] w-[48px] flex-shrink-0 overflow-hidden rounded bg-bg-light shadow-[0_1px_4px_rgba(0,0,0,0.12)]">
+          {item.cover_url ? (
+            /* eslint-disable-next-line @next/next/no-img-element */
+            <img
+              src={item.cover_url}
+              alt={item.title}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center text-[8px] text-text-subtle">
+              No cover
+            </div>
+          )}
+        </div>
+        <div>
+          <p className="font-semibold leading-tight">{item.title}</p>
+          {item.rating !== null && (
+            <p className="mt-0.5 text-sm text-accent">
+              {item.rating}/10
+            </p>
+          )}
+          {item.review && (
+            <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-text-muted">
+              {item.review}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatTimeAgo(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const diffMin = Math.floor(diffMs / 60000);
+  const diffHr = Math.floor(diffMs / 3600000);
+  const diffDay = Math.floor(diffMs / 86400000);
+
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return new Date(dateStr).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+  });
+}

--- a/src/app/(protected)/friends/[friendId]/page.tsx
+++ b/src/app/(protected)/friends/[friendId]/page.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { useAuth } from "@/components/auth-provider";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+
+type Profile = {
+  id: string;
+  display_name: string;
+  username: string;
+  avatar_url: string | null;
+  bio: string | null;
+};
+
+type BookInCommon = {
+  isbn13: string;
+  title: string;
+  cover_url: string | null;
+  my_status: string | null;
+  friend_status: string | null;
+};
+
+type FriendBook = {
+  isbn13: string;
+  title: string;
+  cover_url: string | null;
+  status: string | null;
+  rating: number | null;
+  first_author_name: string | null;
+};
+
+type Favourite = {
+  isbn13: string;
+  rank: number;
+  title: string;
+  cover_url: string | null;
+};
+
+export default function FriendProfilePage() {
+  const { user } = useAuth();
+  const params = useParams();
+  const friendId = params.friendId as string;
+
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [isFriend, setIsFriend] = useState(false);
+  const [booksInCommon, setBooksInCommon] = useState<BookInCommon[]>([]);
+  const [friendBooks, setFriendBooks] = useState<FriendBook[]>([]);
+  const [favourites, setFavourites] = useState<Favourite[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user || !friendId) return;
+    const currentUserId = user.id;
+
+    async function load() {
+      const supabase = createClient();
+
+      // Load profile
+      const { data: profileData } = await supabase
+        .from("profiles")
+        .select("id, display_name, username, avatar_url, bio")
+        .eq("id", friendId)
+        .maybeSingle();
+
+      setProfile(profileData as Profile | null);
+
+      // Check friendship
+      const { data: friendship } = await supabase
+        .rpc("are_friends", {
+          user_id_1: currentUserId,
+          user_id_2: friendId,
+        });
+
+      const areFriends = !!friendship;
+      setIsFriend(areFriends);
+
+      if (areFriends) {
+        // Books in common
+        const { data: common } = await supabase.rpc("get_books_in_common", {
+          user_id_1: currentUserId,
+          user_id_2: friendId,
+        });
+        setBooksInCommon((common as BookInCommon[]) ?? []);
+
+        // Friend's visible library
+        const { data: library } = await supabase
+          .from("user_books_expanded_all")
+          .select("isbn13, title, cover_url, status, rating, first_author_name")
+          .eq("user_id", friendId)
+          .in("visibility", ["public", "friends_only"])
+          .order("created_at", { ascending: false })
+          .limit(20);
+
+        setFriendBooks((library as FriendBook[]) ?? []);
+
+        // Favourites
+        const { data: favs } = await supabase
+          .from("user_favourites")
+          .select("isbn13, rank")
+          .eq("user_id", friendId)
+          .order("rank", { ascending: true });
+
+        if (favs && favs.length > 0) {
+          // Get book metadata for favourites
+          const isbns = favs.map((f: { isbn13: string }) => f.isbn13);
+          const { data: bookMeta } = await supabase
+            .from("books")
+            .select("isbn13, title, image")
+            .in("isbn13", isbns);
+
+          const metaMap = new Map(
+            (bookMeta ?? []).map((b: { isbn13: string; title: string; image: string }) => [
+              b.isbn13,
+              b,
+            ])
+          );
+
+          setFavourites(
+            favs.map((f: { isbn13: string; rank: number }) => ({
+              isbn13: f.isbn13,
+              rank: f.rank,
+              title: (metaMap.get(f.isbn13) as { title: string })?.title ?? "Unknown",
+              cover_url: (metaMap.get(f.isbn13) as { image: string })?.image ?? null,
+            }))
+          );
+        }
+      }
+
+      setLoading(false);
+    }
+
+    load();
+  }, [user, friendId]);
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-2xl px-6 py-12">
+        <p className="text-center text-text-muted">Loading...</p>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="mx-auto max-w-2xl px-6 py-12">
+        <p className="text-center text-text-muted">User not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 pt-4 pb-12 max-sm:px-4">
+      {/* Back link */}
+      <Link
+        href="/friends"
+        className="mb-4 inline-block text-sm text-accent hover:underline"
+      >
+        &larr; Back to friends
+      </Link>
+
+      {/* Profile header */}
+      <div className="mb-8 flex items-center gap-4">
+        {profile.avatar_url ? (
+          /* eslint-disable-next-line @next/next/no-img-element */
+          <img
+            src={profile.avatar_url}
+            alt={profile.display_name}
+            className="h-20 w-20 rounded-full object-cover"
+          />
+        ) : (
+          <div className="flex h-20 w-20 items-center justify-center rounded-full bg-accent/15 text-2xl font-bold text-accent">
+            {profile.display_name?.[0]?.toUpperCase() ?? "?"}
+          </div>
+        )}
+        <div>
+          <h1 className="text-2xl font-bold">{profile.display_name}</h1>
+          <p className="text-text-muted">@{profile.username}</p>
+          {profile.bio && (
+            <p className="mt-1 text-sm text-text-muted">{profile.bio}</p>
+          )}
+        </div>
+      </div>
+
+      {!isFriend ? (
+        <p className="py-8 text-center text-text-muted">
+          You&apos;re not friends with this user. Send them a friend request to
+          see their library.
+        </p>
+      ) : (
+        <>
+          {/* Favourites */}
+          {favourites.length > 0 && (
+            <section className="mb-8">
+              <h2 className="mb-3 text-lg font-bold">Favourites</h2>
+              <div className="flex gap-3 overflow-x-auto">
+                {favourites.map((fav) => (
+                  <div key={fav.isbn13} className="w-20 flex-shrink-0 text-center">
+                    <div className="aspect-[2/3] overflow-hidden rounded-lg bg-bg-medium shadow-[0_1px_4px_rgba(0,0,0,0.12)]">
+                      {fav.cover_url ? (
+                        /* eslint-disable-next-line @next/next/no-img-element */
+                        <img
+                          src={fav.cover_url}
+                          alt={fav.title}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center p-1 text-[10px] text-text-subtle">
+                          {fav.title}
+                        </div>
+                      )}
+                    </div>
+                    <p className="mt-1 text-[10px] font-semibold text-accent">
+                      #{fav.rank}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Books in common */}
+          {booksInCommon.length > 0 && (
+            <section className="mb-8">
+              <h2 className="mb-3 text-lg font-bold">
+                Books in common ({booksInCommon.length})
+              </h2>
+              <div className="grid grid-cols-4 gap-2 sm:grid-cols-5 md:grid-cols-6">
+                {booksInCommon.map((b) => (
+                  <div
+                    key={b.isbn13}
+                    className="aspect-[2/3] overflow-hidden rounded-lg bg-bg-medium shadow-[0_1px_4px_rgba(0,0,0,0.12)]"
+                  >
+                    {b.cover_url ? (
+                      /* eslint-disable-next-line @next/next/no-img-element */
+                      <img
+                        src={b.cover_url}
+                        alt={b.title}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full items-center justify-center p-1 text-[10px] text-text-subtle">
+                        {b.title}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Friend's library */}
+          <section>
+            <h2 className="mb-3 text-lg font-bold">
+              {profile.display_name}&apos;s library
+            </h2>
+            {friendBooks.length === 0 ? (
+              <p className="py-8 text-center text-text-muted">
+                No visible books yet.
+              </p>
+            ) : (
+              <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5">
+                {friendBooks.map((b) => (
+                  <div
+                    key={b.isbn13}
+                    className="aspect-[2/3] overflow-hidden rounded-lg bg-bg-medium shadow-[0_1px_4px_rgba(0,0,0,0.12)]"
+                  >
+                    {b.cover_url ? (
+                      /* eslint-disable-next-line @next/next/no-img-element */
+                      <img
+                        src={b.cover_url}
+                        alt={b.title ?? "Book cover"}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full flex-col items-center justify-center p-2 text-center">
+                        <p className="text-xs font-semibold text-text-muted">
+                          {b.title}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(protected)/friends/page.tsx
+++ b/src/app/(protected)/friends/page.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { useAuth } from "@/components/auth-provider";
+import Link from "next/link";
+
+type Friend = {
+  id: string;
+  display_name: string;
+  username: string;
+  avatar_url: string | null;
+};
+
+type FriendRequest = {
+  id: string;
+  requester_id: string;
+  addressee_id: string;
+  display_name: string;
+  username: string;
+  avatar_url: string | null;
+};
+
+type Tab = "friends" | "requests";
+
+export default function FriendsPage() {
+  const { user } = useAuth();
+  const [tab, setTab] = useState<Tab>("friends");
+  const [friends, setFriends] = useState<Friend[]>([]);
+  const [incoming, setIncoming] = useState<FriendRequest[]>([]);
+  const [outgoing, setOutgoing] = useState<FriendRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [addUsername, setAddUsername] = useState("");
+  const [addError, setAddError] = useState("");
+  const [addSuccess, setAddSuccess] = useState("");
+
+  const loadData = useCallback(async () => {
+    if (!user) return;
+    const supabase = createClient();
+
+    // Load accepted friends
+    const { data: friendRows } = await supabase
+      .from("friendships_expanded")
+      .select("id, requester_id, addressee_id, requester_display_name, requester_username, requester_avatar_url, addressee_display_name, addressee_username, addressee_avatar_url")
+      .eq("status", "accepted");
+
+    const friendList: Friend[] = (friendRows ?? []).map((f: Record<string, string>) => {
+      const isRequester = f.requester_id === user.id;
+      return {
+        id: isRequester ? f.addressee_id : f.requester_id,
+        display_name: isRequester ? f.addressee_display_name : f.requester_display_name,
+        username: isRequester ? f.addressee_username : f.requester_username,
+        avatar_url: isRequester ? f.addressee_avatar_url : f.requester_avatar_url,
+      };
+    });
+    setFriends(friendList);
+
+    // Load pending incoming requests
+    const { data: inRows } = await supabase
+      .from("friendships_expanded")
+      .select("id, requester_id, addressee_id, requester_display_name, requester_username, requester_avatar_url")
+      .eq("status", "pending")
+      .eq("addressee_id", user.id);
+
+    setIncoming(
+      (inRows ?? []).map((r: Record<string, string>) => ({
+        id: r.id,
+        requester_id: r.requester_id,
+        addressee_id: r.addressee_id,
+        display_name: r.requester_display_name,
+        username: r.requester_username,
+        avatar_url: r.requester_avatar_url,
+      }))
+    );
+
+    // Load pending outgoing requests
+    const { data: outRows } = await supabase
+      .from("friendships_expanded")
+      .select("id, requester_id, addressee_id, addressee_display_name, addressee_username, addressee_avatar_url")
+      .eq("status", "pending")
+      .eq("requester_id", user.id);
+
+    setOutgoing(
+      (outRows ?? []).map((r: Record<string, string>) => ({
+        id: r.id,
+        requester_id: r.requester_id,
+        addressee_id: r.addressee_id,
+        display_name: r.addressee_display_name,
+        username: r.addressee_username,
+        avatar_url: r.addressee_avatar_url,
+      }))
+    );
+
+    setLoading(false);
+  }, [user]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  async function handleAccept(requestId: string) {
+    const supabase = createClient();
+    await supabase
+      .from("friendships")
+      .update({ status: "accepted" })
+      .eq("id", requestId);
+    loadData();
+  }
+
+  async function handleReject(requestId: string) {
+    const supabase = createClient();
+    await supabase.from("friendships").delete().eq("id", requestId);
+    loadData();
+  }
+
+  async function handleUnfriend(friendId: string) {
+    if (!user) return;
+    const supabase = createClient();
+    await supabase
+      .from("friendships")
+      .delete()
+      .or(
+        `and(requester_id.eq.${user.id},addressee_id.eq.${friendId}),and(requester_id.eq.${friendId},addressee_id.eq.${user.id})`
+      );
+    loadData();
+  }
+
+  async function handleSendRequest(e: React.FormEvent) {
+    e.preventDefault();
+    if (!user) return;
+    setAddError("");
+    setAddSuccess("");
+
+    const username = addUsername.trim().toLowerCase();
+    if (!username) return;
+
+    const supabase = createClient();
+
+    // Look up user by username
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, username")
+      .eq("username", username)
+      .maybeSingle();
+
+    if (!profile) {
+      setAddError("User not found.");
+      return;
+    }
+
+    if (profile.id === user.id) {
+      setAddError("You can't add yourself.");
+      return;
+    }
+
+    // Check if friendship already exists
+    const { data: existing } = await supabase
+      .from("friendships")
+      .select("id, status")
+      .or(
+        `and(requester_id.eq.${user.id},addressee_id.eq.${profile.id}),and(requester_id.eq.${profile.id},addressee_id.eq.${user.id})`
+      )
+      .maybeSingle();
+
+    if (existing) {
+      setAddError(
+        existing.status === "accepted"
+          ? "You're already friends."
+          : "Request already pending."
+      );
+      return;
+    }
+
+    const { error } = await supabase
+      .from("friendships")
+      .insert({ requester_id: user.id, addressee_id: profile.id });
+
+    if (error) {
+      setAddError("Failed to send request.");
+      return;
+    }
+
+    setAddSuccess(`Friend request sent to @${username}!`);
+    setAddUsername("");
+    loadData();
+  }
+
+  const filteredFriends = search.trim()
+    ? friends.filter(
+        (f) =>
+          f.display_name?.toLowerCase().includes(search.toLowerCase()) ||
+          f.username?.toLowerCase().includes(search.toLowerCase())
+      )
+    : friends;
+
+  const pendingCount = incoming.length + outgoing.length;
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-6 pt-4 pb-12 max-sm:px-4">
+      <h1 className="mb-6 text-3xl font-bold">Friends</h1>
+
+      {/* Send request */}
+      <form onSubmit={handleSendRequest} className="mb-6 flex gap-2">
+        <input
+          type="text"
+          placeholder="Add friend by username..."
+          value={addUsername}
+          onChange={(e) => setAddUsername(e.target.value)}
+          className="flex-1 rounded-(--radius-input) border-[1.5px] border-border bg-bg-light px-4 py-2.5 font-serif text-lg outline-none transition-colors placeholder:text-text-subtle focus:border-accent"
+        />
+        <button
+          type="submit"
+          className="cursor-pointer rounded-(--radius-input) bg-accent px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-88"
+        >
+          Send
+        </button>
+      </form>
+      {addError && <p className="mb-4 text-sm text-error">{addError}</p>}
+      {addSuccess && (
+        <p className="mb-4 text-sm text-green-700">{addSuccess}</p>
+      )}
+
+      {/* Tabs */}
+      <div className="mb-4 flex gap-2">
+        <button
+          onClick={() => setTab("friends")}
+          className={`cursor-pointer rounded-full px-4 py-1.5 text-sm font-semibold transition-colors ${
+            tab === "friends"
+              ? "bg-accent text-white"
+              : "bg-bg-medium text-text-muted hover:bg-accent/10"
+          }`}
+        >
+          Friends ({friends.length})
+        </button>
+        <button
+          onClick={() => setTab("requests")}
+          className={`cursor-pointer rounded-full px-4 py-1.5 text-sm font-semibold transition-colors ${
+            tab === "requests"
+              ? "bg-accent text-white"
+              : "bg-bg-medium text-text-muted hover:bg-accent/10"
+          }`}
+        >
+          Requests{pendingCount > 0 ? ` (${pendingCount})` : ""}
+        </button>
+      </div>
+
+      {loading ? (
+        <p className="py-12 text-center text-text-muted">Loading...</p>
+      ) : tab === "friends" ? (
+        <>
+          {friends.length > 3 && (
+            <input
+              type="text"
+              placeholder="Search friends..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="mb-4 w-full rounded-(--radius-input) border-[1.5px] border-border bg-bg-light px-4 py-2.5 font-serif outline-none transition-colors placeholder:text-text-subtle focus:border-accent"
+            />
+          )}
+          {filteredFriends.length === 0 ? (
+            <p className="py-12 text-center text-text-muted">
+              {friends.length === 0
+                ? "No friends yet. Send a friend request above!"
+                : "No friends match your search."}
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {filteredFriends.map((f) => (
+                <div
+                  key={f.id}
+                  className="flex items-center gap-3 rounded-(--radius-card) border border-border-subtle bg-bg-medium p-3"
+                >
+                  <Avatar url={f.avatar_url} name={f.display_name} />
+                  <Link
+                    href={`/friends/${f.id}`}
+                    className="flex-1 hover:underline"
+                  >
+                    <p className="font-semibold">{f.display_name}</p>
+                    <p className="text-sm text-text-muted">@{f.username}</p>
+                  </Link>
+                  <button
+                    onClick={() => handleUnfriend(f.id)}
+                    className="cursor-pointer text-xs text-text-subtle hover:text-error"
+                  >
+                    Unfriend
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="space-y-6">
+          {/* Incoming */}
+          <div>
+            <h2 className="mb-2 text-sm font-semibold text-text-muted">
+              Incoming ({incoming.length})
+            </h2>
+            {incoming.length === 0 ? (
+              <p className="text-sm text-text-subtle">No pending requests.</p>
+            ) : (
+              <div className="space-y-2">
+                {incoming.map((r) => (
+                  <div
+                    key={r.id}
+                    className="flex items-center gap-3 rounded-(--radius-card) border border-border-subtle bg-bg-medium p-3"
+                  >
+                    <Avatar url={r.avatar_url} name={r.display_name} />
+                    <div className="flex-1">
+                      <p className="font-semibold">{r.display_name}</p>
+                      <p className="text-sm text-text-muted">@{r.username}</p>
+                    </div>
+                    <button
+                      onClick={() => handleAccept(r.id)}
+                      className="cursor-pointer rounded-(--radius-input) bg-accent px-3 py-1 text-xs font-semibold text-white transition-opacity hover:opacity-88"
+                    >
+                      Accept
+                    </button>
+                    <button
+                      onClick={() => handleReject(r.id)}
+                      className="cursor-pointer text-xs text-text-subtle hover:text-error"
+                    >
+                      Reject
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Outgoing */}
+          <div>
+            <h2 className="mb-2 text-sm font-semibold text-text-muted">
+              Outgoing ({outgoing.length})
+            </h2>
+            {outgoing.length === 0 ? (
+              <p className="text-sm text-text-subtle">No sent requests.</p>
+            ) : (
+              <div className="space-y-2">
+                {outgoing.map((r) => (
+                  <div
+                    key={r.id}
+                    className="flex items-center gap-3 rounded-(--radius-card) border border-border-subtle bg-bg-medium p-3"
+                  >
+                    <Avatar url={r.avatar_url} name={r.display_name} />
+                    <div className="flex-1">
+                      <p className="font-semibold">{r.display_name}</p>
+                      <p className="text-sm text-text-muted">@{r.username}</p>
+                    </div>
+                    <span className="text-xs text-text-subtle">Pending</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Avatar({ url, name }: { url: string | null; name: string }) {
+  if (url) {
+    return (
+      /* eslint-disable-next-line @next/next/no-img-element */
+      <img
+        src={url}
+        alt={name}
+        className="h-10 w-10 rounded-full object-cover"
+      />
+    );
+  }
+  return (
+    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-accent/15 text-sm font-bold text-accent">
+      {name?.[0]?.toUpperCase() ?? "?"}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Friends list** (/friends): view, search, and manage friends. Send/accept/reject friend requests by username. Unfriend action.
- **Activity feed** (/feed): friends' reading activity via get_friends_activity_feed RPC. Filter by type (started/finished/reviewed). Paginated with load more.
- **Friend profiles** (/friends/[friendId]): profile header, books in common, friend's visible library, favourites. Respects visibility settings (public + friends_only for accepted friends).

### Notes
- Comments on activities (mentioned in the issue) are not included — the RPCs for this may need to be created first
- All queries use existing Supabase RPCs and views (friendships_expanded, user_books_expanded_all, get_books_in_common, are_friends)

## Fixes
Closes #8

Generated with [Claude Code](https://claude.com/claude-code)