### PR TITLE
feat: add web app manifest (#33)

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "in prose",
+  "short_name": "in prose",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#fbf1ec",
+  "background_color": "#fbf1ec",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,6 +38,7 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  manifest: "/site.webmanifest",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- Added `public/site.webmanifest` with app name, theme colors, and icon
- Linked manifest in Next.js metadata in `layout.tsx`

## Fixes
Closes #33

Generated with [Claude Code](https://claude.com/claude-code)